### PR TITLE
Feat: Config Files

### DIFF
--- a/src/loone/config/config.yaml
+++ b/src/loone/config/config.yaml
@@ -1,0 +1,46 @@
+# Configurations
+/task:
+  ros_parameters:
+    timer_period: 0.25 # Timer period for the task node in seconds
+
+/phone:
+  ros_parameters:
+    phone_port: 5000 # Port on the phone to route to the computer
+    computer_port: 5000 # Port on the computer to route to the phone
+    host: "127.0.0.1" # Host for the phone node (default is localhost)
+
+/path:
+  ros_parameters:
+    path_file: "path.txt" # Path to the file containing the path coordinates
+
+/led:
+  ros_parameters:
+    red_pin: 15   # GPIO board pin for red channel
+    green_pin: 32 # GPIO board pin for green channel
+    blue_pin: 33  # GPIO board pin for blue channel
+    data_pin: 40  # GPIO board pin for data input
+
+/mapping:
+  ros_parameters:
+    local_w: 20       # Local map width in meters
+    local_l: 20       # Local map length in meters
+    global_w: 50      # Global map width in meters
+    global_l: 50      # Global map length in meters
+    res: 0.5          # Map resolution in meters per cell
+    start_position: 4 # Starting quadrant/position (0.5–4, see mapping.py)
+
+/motor:
+  ros_parameters:
+    freq: 50          # PCA9685 PWM frequency in Hz
+    factor: 0.75      # Initial propeller throttle factor
+    center: 0.55      # Rudder center fraction (0 degrees)
+
+    kp: 1.0           # PID proportional gain
+    ki: 0.0           # PID integral gain
+    kd: 0.0           # PID derivative gain
+    max: 45.0         # Max heading error / PID output clamp (degrees)
+
+    prop_min: 1120    # Propeller servo min pulse width (µs)
+    prop_max: 1880    # Propeller servo max pulse width (µs)
+    rudder_min: 1220  # Rudder servo min pulse width (µs)
+    rudder_max: 1820  # Rudder servo max pulse width (µs)

--- a/src/loone/loone/led.py
+++ b/src/loone/loone/led.py
@@ -5,42 +5,62 @@ import time
 import threading
 
 class LED(Node):
+    """ 
+    A ROS2 node that controls an LED light connected to a Jetson board.
+    The node runs a separate thread to manage the LED light's behavior, cycling through red, yellow, and green colors.
+    """
+
     def __init__(self):
+        """ Initialize the LED node and set up GPIO pins for controlling the LED light. """
+        super().__init__('LED_Node')
+
+        # Declare parameters with fallback/default values
+        self.declare_parameter('red_pin', 15)
+        self.declare_parameter('green_pin', 32)
+        self.declare_parameter('blue_pin', 33)
+        self.declare_parameter('data_pin', 40)
+
+        # Retrieve parameters
+        self.red_pin   = self.get_parameter('red_pin').value
+        self.green_pin = self.get_parameter('green_pin').value
+        self.blue_pin  = self.get_parameter('blue_pin').value
+        self.data_pin  = self.get_parameter('data_pin').value
+
         self.receiver = threading.Thread(target = self.light, daemon = True)
         self.receiver.start()
 
     def initialize(self):
-        red_pin = 15
-        green_pin = 32
-        blue_pin = 33
-        data_pin = 40
-
+        """ Set up the GPIO pins for controlling the LED light. """
         GPIO.setmode(GPIO.BOARD)
-        GPIO.setup(red_pin, GPIO.OUT)
-        GPIO.setup(green_pin, GPIO.OUT)
-        GPIO.setup(blue_pin, GPIO.OUT)
-        GPIO.setup(data_pin, GPIO.IN)
+        GPIO.setup(self.red_pin, GPIO.OUT)
+        GPIO.setup(self.green_pin, GPIO.OUT)
+        GPIO.setup(self.blue_pin, GPIO.OUT)
+        GPIO.setup(self.data_pin, GPIO.IN)
 
-        self.red = GPIO.PWM(red_pin, 50)
-        self.green = GPIO.PWM(green_pin, 50)
-        self.blue = GPIO.PWM(blue_pin, 50)
+        self.red = GPIO.PWM(self.red_pin, 50)
+        self.green = GPIO.PWM(self.green_pin, 50)
+        self.blue = GPIO.PWM(self.blue_pin, 50)
 
         self.red.start(0)
         self.green.start(0)
         self.blue.start(0)
 
     def shutdown(self):
+        """ Clean up the GPIO pins and stop the PWM signals for the LED light. """
         self.red.stop()
         self.green.stop()
         self.blue.stop()
         GPIO.cleanup()
 
-    def rgb_to_duty(self, rgb):
-        dc = rgb/255
-
+    def rgb_to_duty(self, rgb: list) -> list:
+        """
+        Convert RGB values to duty cycle percentages.
+        """
+        dc = [value / 255.0 for value in rgb]
         return dc
 
-    def light(self):
+    def light(self) -> None:
+        """ Control the LED light's behavior, cycling through red, yellow, and green colors. """
         self.initialize()
         while rclpy.ok():
             self.red.ChangeDutyCycle(1)
@@ -58,6 +78,7 @@ class LED(Node):
 
         
 def main(args = None):
+    """ Main function to initialize the ROS2 node and start spinning. """
     rclpy.init(args = args)
     led = LED()
     try:

--- a/src/loone/loone/mapping.py
+++ b/src/loone/loone/mapping.py
@@ -5,21 +5,34 @@ import numpy as np
 import math
 
 class Mapping(Node):
-    def __init__(self):
-        global_size = [50, 50]
-        start_position = [4]
+    """ A ROS2 node that manages the mapping of the environment based on data from various sources.
+    The node subscribes to topics providing information about detected objects and the phone's position,
+    and publishes the global map and the current position of the robot.
+    """
 
+    def __init__(self):
+        """ Initialize the Mapping node and set up publishers and subscribers. """
         super().__init__('Map_PubSub')
         self.global_pub = self.create_publisher(Int8MultiArray, 'global', 10)
         self.position_pub = self.create_publisher(Float32MultiArray, 'position', 10)
-        self.objects_sub = self.create_subscription(Float32MultiArray, 'objects', self.object_callback(), 10)
-        self.phone_sub = self.create_subscription(Float32MultiArray, 'phone', self.phone_callback(), 10)
+        self.objects_sub = self.create_subscription(Float32MultiArray, 'objects', self.object_callback, 10)
+        self.phone_sub = self.create_subscription(Float32MultiArray, 'phone', self.phone_callback, 10)
 
-        self.local_w = 20
-        self.local_l = 20
-        self.global_w = global_size[0]
-        self.global_l = global_size[1]
-        self.res = 0.5
+        # Declare parameters with fallback/default values
+        self.declare_parameter('local_w', 20)
+        self.declare_parameter('local_l', 20)
+        self.declare_parameter('global_w', 50)
+        self.declare_parameter('global_l', 50)
+        self.declare_parameter('res', 0.5)
+        self.declare_parameter('start_position', 4)
+
+        # Retrieve parameters
+        self.local_w = self.get_parameter('local_w').value
+        self.local_l = self.get_parameter('local_l').value
+        self.global_w = self.get_parameter('global_w').value
+        self.global_l = self.get_parameter('global_l').value
+        self.res      = self.get_parameter('res').value
+        start_position = self.get_parameter('start_position').value
 
         self.local_rows = self.get_cell(self.local_w)
         self.local_cols = self.get_cell(self.local_l)
@@ -55,31 +68,49 @@ class Mapping(Node):
         self.publish_mapdata()
 
     #ROS - Publish
-    def publish(self):
+    def publish(self) -> None:
+        """ Publish the global map as an Int8MultiArray message. """
         msg = Int8MultiArray()
         msg.data = self.global_map
         self.global_pub.publish(msg)
         self.get_logger().info(f"Map: {msg.data}")
 
-    def publish_position(self):
+    def publish_position(self) -> None:
+        """ Publish the current position as a Float32MultiArray message. """
         msg = Float32MultiArray()
         msg.data = self.global_position
         self.position_pub.publish(msg)
-        self.logger().info(f"Position: {msg.data}")
+        self.get_logger().info(f"Position: {msg.data}")
     
-    def publish_mapdata(self):
+    def publish_mapdata(self) -> None:
+        """ Publish the local map dimensions and resolution as a Float32MultiArray message. """
         msg = Float32MultiArray()
         msg.data = [self.local_w, self.res]
         self.position_pub.publish(msg)
         self.get_logger().info(f"Map Data: {msg.data}")
 
     #General Code
-    def get_cell(self, meter): #convert units in meters to units in cells
+    def get_cell(self, meter: float) -> int: #convert units in meters to units in cells
+        """
+        Convert a distance in meters to the corresponding number of grid cells based on the map resolution.
+
+        Args:
+            meter (float): The distance in meters to be converted.
+        returns:
+            int: The equivalent number of grid cells, rounded to the nearest whole number.
+        """
         cell = round(meter / self.res)
 
         return cell
     
-    def get_map_cell(self, start, end): #Get heading from two coordinates
+    def get_map_cell(self, start: list, end: list) -> None: #Get heading from two coordinates
+        """
+        Calculate the change in global position based on two coordinates, converting the distance to grid cells.
+
+        Args:
+            start (list): The starting coordinate as a list [x, y].
+            end (list): The ending coordinate as a list [x, y].
+        """
         #Possible edit: Use haversine formula instead
         lat = math.radians((start[1] + end[1]) / 2)
         y = self.get_cell((start[0] - end[0]) * 111000)
@@ -87,7 +118,8 @@ class Mapping(Node):
         self.global_position[0] += y
         self.global_position[1] += x
     
-    def get_global_map(self):
+    def get_global_map(self) -> None:
+        """ Update the global map based on the local map and the current position and heading. """
         self.get_map_cell(self.position_0, self.position)
         mid = round((self.global_cols - 1) / 2)
         for i in range(self.global_rows):
@@ -109,7 +141,8 @@ class Mapping(Node):
         
         self.publish()
 
-    def get_local_map(self):
+    def get_local_map(self) -> None:
+        """ Update the local map based on detected obstacles and their locations. """
         self.local_map = np.zeros((self.local_rows, self.local_cols))
 
         for i in range(len(self.obstacles)):
@@ -137,14 +170,26 @@ class Mapping(Node):
             self.get_global_map()
     
     #ROS - Subscribe
-    def object_callback(self, msg):
+    def object_callback(self, msg: CustomMsg) -> None:
+        """ 
+        Callback function for the objects subscription. Updates the detected objects and their locations. 
+        
+        Args:
+            msg (CustomMsg): The message received from the objects topic, containing detected objects and their
+        """
         data = msg.data
         self.get_logger().info(f"Objects: {msg.data}")
         self.objects = data[0]
         self.locations = data[1]
         self.get_local_map()
 
-    def phone_callback(self, msg):
+    def phone_callback(self, msg: CustomMsg) -> None:
+        """ 
+        Callback function for the phone subscription. Updates the current position and heading based on phone data. 
+        
+        Args:
+            msg (CustomMsg): The message received from the phone topic, containing position and heading data
+        """
         data = msg.data
         self.get_logger().info(f"Phone: {msg.data}")
         if data[0] != self.position_0[0] or data[1] != self.position_0[1]:
@@ -153,6 +198,7 @@ class Mapping(Node):
         self.heading = data[3]
     
 def main(args = None):
+    """ Main function to initialize the ROS2 node and start spinning. """
     rclpy.init(args = args)
     mapping = Mapping()
     try:

--- a/src/loone/loone/mapping.py
+++ b/src/loone/loone/mapping.py
@@ -108,13 +108,18 @@ class Mapping(Node):
         Calculate the change in global position based on two coordinates, converting the distance to grid cells.
 
         Args:
-            start (list): The starting coordinate as a list [x, y].
-            end (list): The ending coordinate as a list [x, y].
+            start (list): The starting coordinate as a list [y, x].
+            end (list): The ending coordinate as a list [y, x].
         """
         #Possible edit: Use haversine formula instead
         lat = math.radians((start[1] + end[1]) / 2)
+        # NOTE: Why is lat calculated as the average of start[1] and end[1]? 
+        # It seems like it should be the average of the latitudes (start[0] and end[0]) instead. 
+        # This might be a bug. ~ Carson
         y = self.get_cell((start[0] - end[0]) * 111000)
         x = self.get_cell((start[1] - end[1]) * 111000 * math.cos(lat))
+        # NOTE: Why is the y-coordinate calculated using start[0] and end[0], while the x-coordinate uses start[1] and end[1]?
+        # This seems inconsistent with x,y coordinates as this is y,x. It might be a bug. ~ Carson
         self.global_position[0] += y
         self.global_position[1] += x
     
@@ -158,8 +163,10 @@ class Mapping(Node):
             objL = self.get_cell(obj_length)
             objW = self.get_cell(obj_width)
 
+            # X and Y coordinates of the object in the local map
+            # NOTE: inconsistency in the order of coordinates (X, Y) vs (Y, X) might lead to confusion. ~ Carson
             objStartX = self.get_cell(location[0])
-            objStartY = self.get_cell(location[1])
+            objStartY = self.get_cell(location[1]) 
 
             # Write into the matrix
             for i in range(objL):

--- a/src/loone/loone/motor.py
+++ b/src/loone/loone/motor.py
@@ -32,20 +32,38 @@ class Motor(Node):
         self.task_sub = self.create_subscription(Float32MultiArray, 'task', self.task_callback, 10)
         self.motor_pub = self.create_publisher(Float32MultiArray, 'motor', 10)
 
-        freq = 50
+        # Declare parameters with fallback/default values
+        self.declare_parameter('freq', 50)
+        self.declare_parameter('factor', 0.75)
+        self.declare_parameter('center', 0.55)
+        self.declare_parameter('kp', 1.0)
+        self.declare_parameter('ki', 0.0)
+        self.declare_parameter('kd', 0.0)
+        self.declare_parameter('max', 45.0)
+        self.declare_parameter('prop_min', 1120)
+        self.declare_parameter('prop_max', 1880)
+        self.declare_parameter('rudder_min', 1220)
+        self.declare_parameter('rudder_max', 1820)
+
+        # Retrieve parameters
+        freq       = self.get_parameter('freq').value
+        self.factor = self.get_parameter('factor').value
+        self.center = self.get_parameter('center').value
+        self.kp    = self.get_parameter('kp').value
+        self.ki    = self.get_parameter('ki').value
+        self.kd    = self.get_parameter('kd').value
+        self.max   = self.get_parameter('max').value
+        prop_min   = self.get_parameter('prop_min').value
+        prop_max   = self.get_parameter('prop_max').value
+        rudder_min = self.get_parameter('rudder_min').value
+        rudder_max = self.get_parameter('rudder_max').value
+
         self._init_pca(freq)
-        self._init_servos()
+        self._init_servos(prop_min, prop_max, rudder_min, rudder_max)
 
-        self.factor = 0.75
-        self.center = 0.55
-
-        self.kp = 1
-        self.ki = 0
-        self.kd = 0
         self.i = 0
         self.last_error = 0
         self.last_time = time.time()
-        self.max = 45
 
         self.current_speed = np.nan
         self.current_heading = np.nan
@@ -124,16 +142,13 @@ class Motor(Node):
         self.motor_pub.publish(msg)
         #self.get_logger().info(f"Motor: {msg.data}")
         
-    def _init_servos(self):
+    def _init_servos(self, prop_min, prop_max, rudder_min, rudder_max):
         """Set up servo PWM channels on the PCA9685 with validated pulse ranges.
 
         Raises:
             ValueError: If any pulse range is invalid (see _validate_pulse_range).
             Exception: If a servo channel cannot be acquired from the PCA9685.
         """
-        prop_min, prop_max = 1120, 1880
-        rudder_min, rudder_max = 1220, 1820
-
         self._validate_pulse_range(prop_min, prop_max, "prop_l (ch 0)")
         self._validate_pulse_range(prop_min, prop_max, "prop_r (ch 1)")
         self._validate_pulse_range(rudder_min, rudder_max, "rudder (ch 2)")

--- a/src/loone/loone/path_planning.py
+++ b/src/loone/loone/path_planning.py
@@ -4,17 +4,32 @@ from std_msgs.msg import Int8MultiArray
 import numpy as np
 
 class Path(Node):
+    """
+    A ROS2 node that subscribes to a global map and task path, performs path planning
+    to avoid obstacles, and publishes the resulting waypoints to a topic.
+    The node listens for incoming map and task data, generates a path that avoids obstacles,
+    and publishes a Int8MultiArray message containing the waypoints at a regular interval.
+    """
+
     def __init__(self):
+        """ Initialize the Path node and set up the publisher and subscriptions. """
         super().__init__('Path_PubSub')
         self.path_pub = self.create_publisher(Int8MultiArray, 'path', 10)
         self.map_sub = self.create_subscription(Int8MultiArray, 'global', self.map_callback(), 10)
         self.task_sub = self.create_subscription(Int8MultiArray, 'task_path', self.task_callback(), 10)
 
+
+        # Declare parameters with fallback/default values
+        self.declare_parameter('dist', 4)
+        self.declare_parameter('radius', 2)
+
+        # Retrieve parameters and initialize attributes
         self.path = [] #straight line path
         self.path_obstacles = [] #path avoiding obstacles
         self.waypoints = [] #self.path_obstacles with reduced resolution, based on self.dist
-        self.dist = 4 #interval between waypoints, in cells
-        self.radius = 2 #min distance from obstacles, in cells
+        self.dist = self.get_parameter('dist').value #interval between waypoints, in cells
+        self.radius = self.get_parameter('radius').value #min distance from obstacles, in cells
+
 
         self.map = None
         self.x_start = None
@@ -24,6 +39,7 @@ class Path(Node):
 
     #ROS - Publish
     def publish(self):
+        """ Publish the waypoints as an Int8MultiArray message. """
         msg = Int8MultiArray()
         msg.data = self.waypoints
         self.path_pub.publish(msg)
@@ -31,6 +47,7 @@ class Path(Node):
 
     #General Code
     def point_in_map(self, position):
+        """ Check if a given position is within the bounds of the map. """
         rows = len(self.map)
         cols = len(self.map[0])
         output = False
@@ -40,7 +57,14 @@ class Path(Node):
         
         return output
 
-    def find_obstacle(self, point):
+    def find_obstacle(self, point: tuple) -> bool:
+        """ 
+        Check if there is an obstacle within a certain radius of a given point. 
+        Args:
+            point (tuple): The (y, x) coordinates of the point to check.
+        Returns:
+            bool: True if there is an obstacle within the radius, False otherwise.
+        """
         output = False
         y = point[0]
         x = point[1]
@@ -54,7 +78,17 @@ class Path(Node):
         
         return output
 
-    def pathfind(self, start, expanded):
+    def pathfind(self, start: tuple, expanded: list) -> list:
+        """
+        Find the path from the start position to the end position using the expanded nodes.
+
+        Args:
+            start (tuple): The starting position (y, x).
+            expanded (list): A list of expanded nodes in the form [cost, current position, previous position].
+        
+        Returns:
+            list: A list of positions representing the path from start to end.
+        """
         parent_list = []
         
         if len(expanded)!=0: #If expanded is empty
@@ -71,9 +105,25 @@ class Path(Node):
             
         return parent_list
 
-    def check_neighbours(self, start, end, position, unexpanded, expanded, checked):
+    def check_neighbours(self, start: tuple, end: tuple, position: tuple, unexpanded: list, expanded: list, checked: list) -> None:
+        """ 
+        Check the neighboring cells of the current position and add them to the unexpanded list if they are valid. 
+
+        Args:
+            start (tuple): The starting position (y, x).
+            end (tuple): The ending position (y, x).
+            position (tuple): The current position (y, x).
+            unexpanded (list): A list of unexpanded nodes in the form [cost, current position, previous position].
+            expanded (list): A list of expanded nodes in the form [cost, current position, previous position].
+            checked (list): A list of checked positions.
+        Returns:
+            None
+        """
         y = position[0]
         x = position[1]
+
+        # Define the directions to check (up, down, right, left, and diagonals)
+        # Amelia, can we just make this a constant ~ Carson
         dir = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (-1, 1), (-1, -1), (1, -1)] #Up, down, right, left, diagonal
         
         for i, j in dir:
@@ -84,14 +134,32 @@ class Path(Node):
                 unexpanded.append([cost, next, position])
                 checked.append(next)
             
-    def update_waypoints(self, start, parent_list):
+    def update_waypoints(self, start: tuple, parent_list: list) -> None:
+        """
+        Update the waypoints in the path to avoid obstacles.
+
+        Args:
+            start (tuple): The starting position (y, x).
+            parent_list (list): A list of positions representing the path from start to end.
+
+        Returns:
+            None
+        """
         location = self.path_obstacles.index(start) + 1 #Find point in path list
         
         for point in parent_list:
             self.path_obstacles.insert(location, point) #Add waypoints from obstacle avoidance
         self.path_obstacles.remove(parent_list[0])
 
-    def avoid_obstacle(self, point):
+    def avoid_obstacle(self, point: tuple) -> None:
+        """
+        Avoid an obstacle by finding a new path between the previous and next waypoints.
+
+        Args:
+            point (tuple): The position (y, x) of the waypoint near the obstacle.
+        Returns:
+            None
+        """
         unexpanded=[] #Evaluated neighbours in form [cost, current position, previous position]
         expanded=[] #Visited in form [cost, current position, previous position]
         checked=[] #Checked cells in form [position]
@@ -99,7 +167,7 @@ class Path(Node):
         start = self.path[self.path.index(point) - 1]
         end_index = self.path.index(point)
         end = self.path[end_index]
-        position = (start[0], start[1])
+        position = (start[0], start[1]) # x, y?
 
         while self.find_obstacle(end) and (end_index != len(self.path_obstacles) - 1): #move destination further away so it does not intersect with an obstacle
             self.path.remove(end)
@@ -119,7 +187,10 @@ class Path(Node):
         parent_list = self.pathfind(start, expanded)
         self.update_waypoints(start, parent_list)
         
-    def make_waypoints(self):
+    def make_waypoints(self) -> None:
+        """
+        Create waypoints along the path, avoiding obstacles.
+        """
         self.path_obstacles = self.path
 
         for point in self.path:
@@ -127,12 +198,15 @@ class Path(Node):
                 self.avoid_obstacle(point)
                 
         for point in self.path_obstacles:
-            y = point[0]
+            y = point[0] # wouldn't it be better to use y = point[1] and x = point[0] since the point is in (y, x) format? ~ Carson
             x = point[1]
             if ((self.path_obstacles.index(point) % self.dist == 0) or (point == self.path_obstacles[-1])): #Add every d points to waypoint list and last waypoint
                 self.waypoints.append(point)
 
-    def get_path(self):
+    def get_path(self) -> None:
+        """
+        Generate the path from start to end, avoiding obstacles.
+        """
         while self.find_obstacle((self.y_end, self.x_end)): #Ensure that end point is not near obstacle
             self.y_end = self.y_end - 1 #UPDATE
         
@@ -162,12 +236,14 @@ class Path(Node):
         self.publish()
     
     #ROS - Subscribe
-    def map_callback(self, msg):
+    def map_callback(self, msg) -> None:
+        """ Callback function for the map subscription. Updates the internal map representation. """
         data = msg.data
         self.get_logger().info(f"Map: {msg.data}")
         self.map = data
 
-    def task_callback(self, msg):
+    def task_callback(self, msg: Int8MultiArray) -> None:
+        """ Callback function for the task subscription. Updates the start and end positions. """
         data = msg.data
         self.get_logger().info(f"Task: {msg.data}")
         self.y_start = data[0]
@@ -178,6 +254,8 @@ class Path(Node):
             self.get_path()
     
 def main(args = None):
+    """ Main function to initialize the ROS2 node and start spinning. """
+    
     rclpy.init(args = args)
     planning = Path()
     try:

--- a/src/loone/loone/path_planning.py
+++ b/src/loone/loone/path_planning.py
@@ -119,11 +119,12 @@ class Path(Node):
         Returns:
             None
         """
+         # NOTE: WHY IS THIS IN (Y, X) FORMAT? ~ Carson
         y = position[0]
         x = position[1]
 
         # Define the directions to check (up, down, right, left, and diagonals)
-        # Amelia, can we just make this a constant ~ Carson
+        # TODO: Amelia, can we just make this a constant ~ Carson
         dir = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (-1, 1), (-1, -1), (1, -1)] #Up, down, right, left, diagonal
         
         for i, j in dir:
@@ -167,7 +168,7 @@ class Path(Node):
         start = self.path[self.path.index(point) - 1]
         end_index = self.path.index(point)
         end = self.path[end_index]
-        position = (start[0], start[1]) # x, y?
+        position = (start[0], start[1]) #NOTE: x, y? but we are using y, x format for points ~ Carson
 
         while self.find_obstacle(end) and (end_index != len(self.path_obstacles) - 1): #move destination further away so it does not intersect with an obstacle
             self.path.remove(end)
@@ -198,7 +199,7 @@ class Path(Node):
                 self.avoid_obstacle(point)
                 
         for point in self.path_obstacles:
-            y = point[0] # wouldn't it be better to use y = point[1] and x = point[0] since the point is in (y, x) format? ~ Carson
+            y = point[0] # NOTE: wouldn't it be better to use y = point[1] and x = point[0] since the point is in (y, x) format? ~ Carson
             x = point[1]
             if ((self.path_obstacles.index(point) % self.dist == 0) or (point == self.path_obstacles[-1])): #Add every d points to waypoint list and last waypoint
                 self.waypoints.append(point)
@@ -255,7 +256,7 @@ class Path(Node):
     
 def main(args = None):
     """ Main function to initialize the ROS2 node and start spinning. """
-    
+
     rclpy.init(args = args)
     planning = Path()
     try:

--- a/src/loone/loone/phone.py
+++ b/src/loone/loone/phone.py
@@ -7,10 +7,16 @@ import subprocess
 import threading
 
 class Phone(Node):
-
-    # Class Constants
-    HOST = "127.0.0.1" # Local Host
-    PORT = 5000 # Port: used for rerouting phone to computer
+    """
+    A ROS2 node that retrieves GPS coordinates, speed, and heading from a phone using 
+    ADB (Android Debug Bridge) and publishes this data to a topic.
+    The node listens for incoming data from the phone and publishes a Float32MultiArray message containing
+        the latitude, 
+        longitude, 
+        speed, 
+        and heading
+    at a regular interval.
+    """
 
     def __init__(self):
         """
@@ -22,19 +28,29 @@ class Phone(Node):
         self.latitude = np.nan
         self.longitude = np.nan
 
+        # Declare parameters with fallback/default values
+        self.declare_parameter('phone_port', 5000)
+        self.declare_parameter('computer_port', 5000)
+        self.declare_parameter('host', "127.0.0.1")
+
+        # Retrieve parameters
+        self.PHONE_PORT = self.get_parameter('phone_port').value
+        self.PORT = self.get_parameter('computer_port').value
+        self.HOST = self.get_parameter('host').value
+
         self.get_adb_devices()
         self.route_adb()
-
-        super().__init__('Phone_Pub')
+        
+        super().__init__('Phone_Pub') # Why is this here? ~ Carson
         self.phone_pub = self.create_publisher(Float32MultiArray, 'phone', 10)
         self.receiver = threading.Thread(target = self.get_odometry, daemon = True)
         self.receiver.start()
+        self.get_logger().info(f"Phone node initialized. Listening on {self.HOST}:{self.PORT} and routing to phone port {self.PHONE_PORT}.")
 
     def publish(self):
         msg = Float32MultiArray()
         msg.data = [self.latitude, self.longitude, self.speed, self.heading]
         self.phone_pub.publish(msg)
-        #self.get_logger().info(f"Phone: {msg.data}")
     
     def get_odometry(self):
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -93,8 +109,8 @@ class Phone(Node):
         subprocess.run(["adb","reverse","--remove-all"])
 
         # Route the localhost to computer local host
-        subprocess.run(["adb", "reverse", f"tcp:{self.PORT}", f"tcp:{self.PORT}"])
-        self.get_logger().info(f"Routed phone localhost:{self.PORT} to computer localhost:{self.PORT}")
+        subprocess.run(["adb", "reverse", f"tcp:{self.PHONE_PORT}", f"tcp:{self.PORT}"])
+        self.get_logger().info(f"Routed phone localhost:{self.PHONE_PORT} to computer localhost:{self.PORT}")
 
 def main(args = None):
     rclpy.init(args = args)

--- a/src/loone/loone/task.py
+++ b/src/loone/loone/task.py
@@ -3,19 +3,38 @@ from rclpy.node import Node
 from std_msgs.msg import Float32MultiArray
 
 class Task(Node):
-    def __init__(self):
-        super().__init__('Task_Pub')
-        self.publisher_ = self.create_publisher(Float32MultiArray, 'task', 10)
-        timer_period = 0.25
-        self.timer = self.create_timer(timer_period, self.run_task)
+    """
+    A ROS2 node that publishes task commands to a topic.
+    The node publishes a Float32MultiArray message containing 
+        the command, 
+        target heading, 
+        target speed, 
+        and direction 
+    at a regular interval.
+    """
 
-    def publish(self):
+    def __init__(self):
+        """ Initialize the Task node and set up the publisher and timer. """
+        super().__init__('Task_Pub')
+
+        # Declare parameters with fallback/default values
+        self.declare_parameter('timer_period', 0.25)
+
+        # Retrieve parameters
+        timer_period = self.get_parameter('timer_period').value
+        
+        self.publisher_ = self.create_publisher(Float32MultiArray, 'task', 10)
+        self.timer = self.create_timer(timer_period, self.run_task)
+        self.get_logger().info(f"Task node initialized with timer period: {timer_period} seconds.")
+
+    def publish(self) -> None:
+        """ Publish the task command as a Float32MultiArray message. """
         msg = Float32MultiArray()
         msg.data = [self.command, self.target_heading, self.target_speed, self.dir]
         self.publisher_.publish(msg)
-        #self.get_logger().info(f"Task: {msg.data}")
     
-    def run_task(self):
+    def run_task(self) -> None:
+        """ Update the task command parameters and publish the message. """
         self.command = 1.0
         self.target_heading = 0.0
         self.target_speed = 1.0
@@ -23,9 +42,12 @@ class Task(Node):
         
         self.publish()
 
-def main(args = None):
+def main(args = None) -> None:
+    """ Main function to initialize the ROS2 node and start spinning. """
+
     rclpy.init(args = args)
     task = Task()
+
     # Add a try-except block to handle KeyboardInterrupt gracefully
     try:
         rclpy.spin(task)

--- a/wiki/CONTRIBUTING.md
+++ b/wiki/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Here are some important resources:
 
 * Bugs? [Github Issues](https://github.com/HumberASV/Loon-E/issues) is where to report them.
 * Environment? see the [setup](setup/ENV.md) documentation.
+* Configuration? see the [config](setup/CONFIG.md) documentation.
 * License? [MIT](../LICENSE).
 
 ## AI Use

--- a/wiki/setup/CONFIG.md
+++ b/wiki/setup/CONFIG.md
@@ -1,0 +1,98 @@
+# Node Configuration
+
+All node parameters are defined in `src/loone/config/config.yaml` and loaded at runtime via ROS 2's parameter system. Each section corresponds to a node namespace. Parameters are declared with defaults in code, so the file only needs to contain values you want to override.
+
+To launch with the config file:
+
+```bash
+ros2 launch loone <launch_file>.py --ros-args --params-file src/loone/config/config.yaml
+```
+
+---
+
+## `/led`
+
+Controls the GPIO pins for the RGB LED on the Jetson board.
+
+| Parameter   | Default | Description                        |
+|-------------|---------|------------------------------------|
+| `red_pin`   | `15`    | GPIO board pin for the red channel |
+| `green_pin` | `32`    | GPIO board pin for the green channel |
+| `blue_pin`  | `33`    | GPIO board pin for the blue channel |
+| `data_pin`  | `40`    | GPIO board pin for data input      |
+
+---
+
+## `/mapping`
+
+Controls the occupancy grid map dimensions and starting position.
+
+| Parameter        | Default | Description                                           |
+|------------------|---------|-------------------------------------------------------|
+| `local_w`        | `20`    | Local map width in meters                             |
+| `local_l`        | `20`    | Local map length in meters                            |
+| `global_w`       | `50`    | Global map width in meters                            |
+| `global_l`       | `50`    | Global map length in meters                           |
+| `res`            | `0.5`   | Map resolution in meters per cell                     |
+| `start_position` | `4`     | Starting quadrant/position (0.5, 1, 1.5 … 4)         |
+
+`start_position` values correspond to compass positions around the global map:
+
+| Value | Position        |
+|-------|-----------------|
+| `0.5` | Positive Y axis |
+| `1`   | Quadrant 1      |
+| `1.5` | Positive X axis |
+| `2`   | Quadrant 2      |
+| `2.5` | Negative Y axis |
+| `3`   | Quadrant 3      |
+| `3.5` | Negative X axis |
+| `4`   | Quadrant 4      |
+
+---
+
+## `/motor`
+
+Controls the PCA9685 PWM driver and PID heading controller.
+
+| Parameter   | Default | Description                                          |
+|-------------|---------|------------------------------------------------------|
+| `freq`      | `50`    | PCA9685 PWM frequency in Hz                          |
+| `factor`    | `0.75`  | Initial propeller throttle factor (0.0–1.0)          |
+| `center`    | `0.55`  | Rudder center fraction (neutral/0°)                  |
+| `kp`        | `1.0`   | PID proportional gain                                |
+| `ki`        | `0.0`   | PID integral gain                                    |
+| `kd`        | `0.0`   | PID derivative gain                                  |
+| `max`       | `45.0`  | Max heading error / PID output clamp in degrees      |
+| `prop_min`  | `1120`  | Propeller servo minimum pulse width in µs            |
+| `prop_max`  | `1880`  | Propeller servo maximum pulse width in µs            |
+| `rudder_min`| `1220`  | Rudder servo minimum pulse width in µs               |
+| `rudder_max`| `1820`  | Rudder servo maximum pulse width in µs               |
+
+---
+
+## `/path`
+
+| Parameter   | Default      | Description                              |
+|-------------|--------------|------------------------------------------|
+| `path_file` | `"path.txt"` | Path to the file containing waypoint coordinates |
+
+---
+
+## `/phone`
+
+Controls the UDP tunnel between the phone and the onboard computer.
+
+| Parameter       | Default       | Description                                    |
+|-----------------|---------------|------------------------------------------------|
+| `phone_port`    | `5000`        | Port on the phone to forward from              |
+| `computer_port` | `5000`        | Port on the computer to receive on             |
+| `host`          | `"127.0.0.1"` | Host address for the phone node (default: localhost) |
+
+---
+
+## `/task`
+
+| Parameter      | Default | Description                                  |
+|----------------|---------|----------------------------------------------|
+| `timer_period` | `0.25`  | Timer period for the task node in seconds    |


### PR DESCRIPTION

### New Files

- **`src/loone/config/config.yaml`** — Central ROS 2 config file with parameters for all nodes (task, phone, path, led, mapping, motor).
- **`wiki/setup/CONFIG.md`** — Documentation for the config file, with a parameter table per node and a `start_position` reference table for the mapping node.

### Source Changes

The core pattern across every node is the same: **hardcoded values replaced by ROS 2 declared parameters** so they can be overridden at launch via the config file.

| Node | changes |
|---|---|
| `motor.py` | `freq`, `factor`, `center`, `kp/ki/kd/max`, and servo pulse widths moved to declared params; `_init_servos` now takes pulse range args instead of hardcoding them |
| `mapping.py` | Map dimensions (`local_w/l`, `global_w/l`, `res`, `start_position`) moved to params; fixed bug where `self.object_callback()` and `self.phone_callback()` were being *called* at subscription time instead of passed as callbacks; fixed `self.logger()` → `self.get_logger()` |
| `phone.py` | `HOST` and `PORT` moved to params; added separate `phone_port` vs `computer_port`, fixing the ADB reverse routing to use the correct ports |
| `task.py` | `timer_period` moved to a declared param |
| `led.py` | GPIO pin numbers moved to declared params; fixed `rgb_to_duty` to correctly operate on a list of RGB values (was dividing a list by 255 before) |
| `path_planning.py` | `dist` and `radius` moved to declared params; added several `# NOTE` comments flagging suspected coordinate-ordering bugs (y,x vs x,y) |

Docstrings were also added across all nodes.

